### PR TITLE
Remove maxNumberOfMessages option

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,6 @@ const Consumer = require('@aptoma/sqs-consumer');
 const app = new Consumer({
 	queueUrl: 'https://sqs.eu-central-1.amazonaws.com/....',
 	batchSize: 15,
-	maxNumberOfMessages: 10,
 	waitTimeSeconds: 10,
 	aws: {
 		region: 'eu-central-1'

--- a/index.js
+++ b/index.js
@@ -13,13 +13,11 @@ class SQSConsumer extends EventEmitter {
 		aws = {},
 		messageAttributeNames = [],
 		batchSize = 1,
-		maxNumberOfMessages = 1,
 		waitTimeSeconds = 0,
 		handleMessage
 	}) {
 		super();
 		this.queueUrl = queueUrl;
-		this.maxNumberOfMessages = maxNumberOfMessages;
 		this.messageAttributeNames = messageAttributeNames;
 		this.waitTimeSeconds = waitTimeSeconds;
 		this.handleMessage = handleMessage;
@@ -45,7 +43,7 @@ class SQSConsumer extends EventEmitter {
 			QueueUrl: this.queueUrl,
 			AttributeNames: ['All'],
 			MessageAttributeNames: this.messageAttributeNames,
-			MaxNumberOfMessages: this.maxNumberOfMessages,
+			MaxNumberOfMessages: this.getMaxNumberOfMessages(),
 			WaitTimeSeconds: this.waitTimeSeconds
 		};
 
@@ -76,6 +74,17 @@ class SQSConsumer extends EventEmitter {
 		} finally {
 			clearTimeout(timeout);
 		}
+	}
+
+	getMaxNumberOfMessages() {
+		let max = this.batchSize - this.numActiveMessages;
+		if (max > 10) {
+			max = 10;
+		} else if (max < 1) {
+			max = 1;
+		}
+
+		return max;
 	}
 
 	async shouldWePoll() {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -64,6 +64,30 @@ describe('SQS Consumer', () => {
 		});
 	});
 
+	describe('getMaxNumberOfMessages()', () => {
+		it('should return max 10', () => {
+			consumer.batchSize = 15;
+			consumer.numActiveMessages = 0;
+			expect(consumer.getMaxNumberOfMessages()).to.equal(10);
+		});
+
+		it('should return batchSize - numActiveMessages', () => {
+			consumer.batchSize = 15;
+			consumer.numActiveMessages = 10;
+			expect(consumer.getMaxNumberOfMessages()).to.equal(5);
+		});
+
+		it('should never be less than 1', () => {
+			consumer.batchSize = 15;
+			consumer.numActiveMessages = 15;
+			expect(consumer.getMaxNumberOfMessages()).to.equal(1);
+
+			consumer.batchSize = 15;
+			consumer.numActiveMessages = 20;
+			expect(consumer.getMaxNumberOfMessages()).to.equal(1);
+		});
+	});
+
 	describe('handleMessage', () => {
 		it('callback with error returns message to queue', async () => {
 			consumer.handleMessage = sandbox.stub().callsArgWith(1, new Error('shit'));


### PR DESCRIPTION
It was a bit confusing before. e.g using `maxNumberOfMessage = 10` and `batchSize = 10` could result in processing 19 message at one time. 
