### PR TITLE
Always check polling after callback

### DIFF
--- a/index.js
+++ b/index.js
@@ -109,6 +109,7 @@ class SQSConsumer extends EventEmitter {
 	createCallback(msg) {
 		return async (err) => {
 			this.numActiveMessages--;
+			this.shouldWePoll();
 			if (err) {
 				try {
 					await this.returnMessageToQueue(msg.ReceiptHandle);


### PR DESCRIPTION
Couldn't find a good way to write a test for this. I made a throwaway script for checking before/after but it's kinda janky and not necessarily something we need to keep around. The results were pretty clear though. If your jobs are shorter than a second in length (which a lot of the resizes are), you save a potentially massive amount of completely dead time by polling more aggressively.