### PR TITLE
Add graceful shutdown

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
 'use strict';
+
 const AWS = require('aws-sdk');
 const EventEmitter = require('events');
 
@@ -143,12 +144,18 @@ class SQSConsumer extends EventEmitter {
 		}
 	}
 
-	stop() {
+	async stop(timeout = 20 * 1000) {
 		this.active = false;
 		this.abort();
 		clearInterval(this.intervalId);
+		const start = Date.now();
+		while (Date.now() > start - timeout) {
+			if (this.numActiveMessages <= 0) {
+				break;
+			}
+			await new Promise((resolve) => setTimeout(resolve, 10));
+		}
 	}
-
 }
 
 module.exports = SQSConsumer;

--- a/index.js
+++ b/index.js
@@ -144,12 +144,15 @@ class SQSConsumer extends EventEmitter {
 		}
 	}
 
-	async stop(timeout = 20 * 1000) {
+	async stop(gracefulTimeout = 0) {
 		this.active = false;
 		this.abort();
 		clearInterval(this.intervalId);
+		if (!gracefulTimeout || isNaN(Number(gracefulTimeout))) {
+			return;
+		}
 		const start = Date.now();
-		while (Date.now() > start - timeout) {
+		while (Date.now() > start - Number(gracefulTimeout)) {
 			if (this.numActiveMessages <= 0) {
 				break;
 			}

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -66,17 +66,24 @@ describe('SQS Consumer', () => {
 	});
 
 	describe('stop()', () => {
+		it('should return right away if gracefulTimeout is falsy', async () => {
+			await consumer.start();
+			consumer.numActiveMessages = 1;
+			const shutdownPromise = consumer.stop();
+			await Promise.race([shutdownPromise, new Promise((resolve, reject) => reject('still running'))]);
+		});
+
 		it('should return right away if we have no active messages', async () => {
 			await consumer.start();
 			consumer.numActiveMessages = 0;
-			const shutdownPromise = consumer.stop();
+			const shutdownPromise = consumer.stop(20 * 1000);
 			await Promise.race([shutdownPromise, new Promise((resolve, reject) => reject('still running'))]);
 		});
 
 		it('should wait until active messages have been drained before returning', async () => {
 			await consumer.start();
 			consumer.numActiveMessages = 1;
-			const shutdownPromise = consumer.stop();
+			const shutdownPromise = consumer.stop(20 * 1000);
 
 			let res = await Promise.race([shutdownPromise, new Promise((resolve) => resolve('still running'))]);
 			expect(res).to.equal('still running');


### PR DESCRIPTION
The SQS-consumer does not currently wait for active messages to finish before returning from the shutdown function. This may cause PDF jobs to be interrupted when deploying brokkr, as there's nothing else that keeps track of active jobs.